### PR TITLE
Ensure white backgrounds and black text

### DIFF
--- a/header.html
+++ b/header.html
@@ -28,7 +28,7 @@
       font-family: 'Goudy Bookletter 1911', Georgia, "Times New Roman", serif;
       line-height: 1.2;
       background: #fff;
-      color: #111;
+      color: #000;
     }
     a { text-decoration: none; color: inherit; }
     header {
@@ -36,6 +36,8 @@
       text-align: center;
       max-width: var(--max-width);
       margin: 0 auto;
+      background: #fff;
+      color: #000;
     }
     .numbers-top { 
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;

--- a/styles.css
+++ b/styles.css
@@ -2,16 +2,18 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
+  background: #fff;
+  color: #000;
 }
 
 header {
-  background: #000;
-  color: #fff;
+  background: #fff;
+  color: #000;
   padding: 1rem;
 }
 
 nav a {
-  color: #fff;
+  color: #000;
   margin-right: 1rem;
   text-decoration: none;
 }
@@ -21,7 +23,8 @@ main {
 }
 
 footer {
-  background: #f5f5f5;
+  background: #fff;
   text-align: center;
   padding: 1rem;
+  color: #000;
 }


### PR DESCRIPTION
## Summary
- Ensure body, header, navigation, and footer use white backgrounds with black text
- Adjust header snippet so all text is black and background white

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e8fedf0e48333add96f3af4f94eb8