### PR TITLE
Link header numbers to collections page via query string

### DIFF
--- a/collection.html
+++ b/collection.html
@@ -19,6 +19,17 @@
   <footer>
     <p>&copy; 2024 Maison Margiela</p>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const number = window.location.search.slice(1);
+      if (number) {
+        const heading = document.querySelector('main h2');
+        if (heading) {
+          heading.textContent = `Collection ${number}`;
+        }
+      }
+    });
+  </script>
   <script src="header.js"></script>
 </body>
 </html>

--- a/header.js
+++ b/header.js
@@ -5,6 +5,19 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(response => response.text())
       .then(html => {
         container.innerHTML = html;
+
+        // After injecting the header, wire up number links so they navigate
+        // to the collections page with a query string corresponding to the
+        // clicked number. For example, clicking "18" will redirect to
+        // "collection.html?18".
+        const numberLinks = container.querySelectorAll('.numbers-top a');
+        numberLinks.forEach(link => {
+          link.addEventListener('click', evt => {
+            evt.preventDefault();
+            const number = link.textContent.trim();
+            window.location.href = `collection.html?${number}`;
+          });
+        });
       });
   }
 });


### PR DESCRIPTION
## Summary
- redirect header number links to `collection.html` with the clicked number as the query string
- show selected collection number on the collection page based on the query string

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e9193aa7c8333a80843500a04cee7