### PR TITLE
Ensure brand link sits below collection numbers

### DIFF
--- a/header.html
+++ b/header.html
@@ -39,12 +39,12 @@
       background: #fff;
       color: #000;
     }
-    .numbers-top { 
+    .numbers-top {
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
       font-size: 0.9rem;
       letter-spacing: 0; /* tightened so rows align */
       margin-bottom: 0.25rem;
-      display: inline-block;
+      display: block;
       text-align: center;
       line-height: 1.1;
       width: calc(7 * 2.4em + 6px); /* invisible bounding box matching 7-item rows */


### PR DESCRIPTION
## Summary
- Stack the Maison Martin Margiela PARIS link below the number grid by switching the number container to block display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e9267d378833383a5cfe69b1774fa