### PR TITLE
Add squaricle card grid to collection page

### DIFF
--- a/collection.html
+++ b/collection.html
@@ -10,11 +10,7 @@
   <div id="header"></div>
   <main>
     <h2>Collection</h2>
-    <ul>
-      <li>Artisanal Line</li>
-      <li>Ready-to-Wear</li>
-      <li>Footwear</li>
-    </ul>
+    <div class="collection-grid"></div>
   </main>
   <footer>
     <p>&copy; 2024 Maison Margiela</p>
@@ -26,6 +22,16 @@
         const heading = document.querySelector('main h2');
         if (heading) {
           heading.textContent = `Collection ${number}`;
+        }
+      }
+
+      const grid = document.querySelector('.collection-grid');
+      if (grid) {
+        for (let i = 1; i <= 40; i++) {
+          const card = document.createElement('div');
+          card.className = 'squaricle-card';
+          card.textContent = i;
+          grid.appendChild(card);
         }
       }
     });

--- a/styles.css
+++ b/styles.css
@@ -28,3 +28,20 @@ footer {
   padding: 1rem;
   color: #000;
 }
+
+.collection-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.squaricle-card {
+  aspect-ratio: 1 / 1;
+  border-radius: 20%;
+  background: #e0e0e0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- Fill collection page with 10x4 squaricle card grid
- Style grid and cards with CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e92ed19408333b6c793df5e8adf3b