### PR TITLE
fix: ensure number links open collections page

### DIFF
--- a/header.js
+++ b/header.js
@@ -7,16 +7,13 @@ document.addEventListener('DOMContentLoaded', () => {
         container.innerHTML = html;
 
         const numberLinks = container.querySelectorAll('.numbers-top a');
-        const isCollectionPage = window.location.pathname.includes('collection.html');
-        if (isCollectionPage) {
-          numberLinks.forEach(link => {
-            link.addEventListener('click', evt => {
-              evt.preventDefault();
-              const number = link.textContent.trim();
-              window.location.href = `collection.html?${number}`;
-            });
+        numberLinks.forEach(link => {
+          link.addEventListener('click', evt => {
+            evt.preventDefault();
+            const number = link.textContent.trim();
+            window.location.href = `collection.html?${number}`;
           });
-        }
+        });
 
         if (window.initScrollSpy) {
           window.initScrollSpy();


### PR DESCRIPTION
## Summary
- ensure number links always redirect to `collection.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e94eb1408833384ba5a72c95920b7