### PR TITLE
Ensure collection text sits beside numbers on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,12 +173,6 @@
 
     /* Responsive tweaks */
     @media (max-width: 800px) {
-      .collection {
-        flex-direction: column;
-      }
-      .number-circle {
-        margin-bottom: 4px;
-      }
       .nav-wrapper {
         overflow-x: auto;
         padding: 0 0.5rem;


### PR DESCRIPTION
## Summary
- Prevent mobile layout from stacking collection numbers and text vertically

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e950e204483339fd9024d3ec91080