### PR TITLE
Add detailed collection descriptions to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <title>Maison Martin Margiela</title>
@@ -209,94 +209,282 @@
     <section id="section-0" class="collection" aria-labelledby="title-0">
       <div class="number-circle" aria-hidden="true">0</div>
       <div class="texts">
-        <h2 id="title-0">Collection “Artisanal” pour femme & homme</h2>
-        <p>La collection défilé pour femme <span class="asterisk">*</span></p>
+        <h2 id="title-0">“Artisanal” collection for women &amp; men</h2>
+        <p>The women’s runway collection <span class="asterisk">*</span></p>
+        <div class="description">
+          <p>The Artisanal line is the lodestar of Margiela’s universe—every piece feels like a secret ritual performed in plain sight. These are not merely clothes but hand-assembled thought experiments, stitched from found fragments, reworked vintage, or materials rescued from cultural detritus. The all-white label, attached with four visible stitches and devoid of overt authorship, signals a refusal of traditional fashion celebrity while inviting obsessive decoding. To wear Artisanal is to carry a layered history: it is couture without ceremony, rebellion cloaked in craftsmanship.</p>
+          <p>Over decades, Artisanal has oscillated between myth and manifestation. Though formally circled as “0” in the numbered system, its influence radiates beyond its own shows—its principles leak into the house’s identity, whispering through the other lines. What fascinates devotees is the way it preserves ambiguity; every piece feels like a fragment of a larger, unrevealed manifesto, a work that simultaneously hides and reveals Margiela’s philosophical core.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-1" class="collection" aria-labelledby="title-1">
       <div class="number-circle" aria-hidden="true">1</div>
       <div class="texts">
-        <h2 id="title-1">La collection pour femme</h2>
+        <h2 id="title-1">The women’s collection</h2>
+        <div class="description">
+          <p>Line 1 is Margiela’s foundational ready-to-wear voice for women, where radical ideas are rendered with a practiced economy of gesture. It’s here that conceptual deconstruction wears the uniform of apparent simplicity: exposed seams, reconstructed silhouettes, and archival homage that reads as both critique and celebration. The “Replica” impulse—preserving and reimagining the past—is a running whisper in the line, where garments feel familiar because they are subtly recontextualized reflections of collective dress memory.</p>
+          <p>What makes Line 1 intoxicating to an obsessed watcher is its duality: it is deeply wearable and profoundly interrogative. The circled “1” on the label isn’t a brand stamp so much as a punctuation mark in a long-form linguistic system—this collection speaks in dialects of intentional opacity, inviting interpretation while withholding definitive explanation. Each season yields artifacts that feel like archaeological finds from a future museum of taste.</p>
+        </div>
       </div>
     </section>
 
-    <section id="section-4" class="collection" aria-labelledby="title-4">
-      <div class="number-circle" aria-hidden="true">4</div>
+    <section id="section-2" class="collection" aria-labelledby="title-2">
+      <div class="number-circle" aria-hidden="true">2</div>
       <div class="texts">
-        <h2 id="title-4">Garde-robe pour femme</h2>
+        <h2 id="title-2">—</h2>
+        <p>Content coming soon.</p>
+        <div class="description">
+          <p>Line 2 is the deliberate silence in Margiela’s taxonomy, a space that enthusiasts circle in the margins with speculative fervor. Its absence is its signature; it refuses to be pinned, catalogued, or normalized, and in that refusal it becomes a mirror reflecting what the Maison chooses not to define. The mystery around 2 sustains an entire subculture of analysis—was it reserved, tested internally, or left blank as a conceptual pause? The lack of a public narrative is itself a curated gesture.</p>
+          <p>That vacancy absorbs projection. Collectors, archivists, and obsessive readers of the grid assign to it stories, rumors, phantom projects, and internal experiments that may never have had form. The beauty of Line 2 is that it functions as a breathing gap in an otherwise schematized universe: a quiet invitation to wonder what could have been, could still be, or was never meant to be spoken.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-3" class="collection" aria-labelledby="title-3">
       <div class="number-circle" aria-hidden="true">3</div>
       <div class="texts">
-        <h2 id="title-3">Collection de fragrances</h2>
+        <h2 id="title-3">Fragrance collection</h2>
+        <div class="description">
+          <p>The fragrance collection takes Margiela’s fixation on memory and materializes it in scent. These aren’t perfumes built around celebrity or trend, but olfactive capsules—moments in time distilled, labeled, and entrusted to the wearer’s own internal archive. The design feels like an extension of the house’s deconstructive ethos: fragrances named after experiences or atmospheres, carried in clinical, reductive packaging that divorces luxury from ostentation and instead offers intimacy.</p>
+          <p>What makes this line compelling to a devotee is the way smell becomes narrative—each bottle is a reconstruction of a scene, a translation of sensation into form. The obsessive fan traces connections between a fragrance and the way Margiela once dismantled a jacket or repurposed a stitch: the same method of making the familiar strange, then tenderly reclaiming it.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-4" class="collection" aria-labelledby="title-4">
+      <div class="number-circle" aria-hidden="true">4</div>
+      <div class="texts">
+        <h2 id="title-4">Women’s wardrobe</h2>
+        <div class="description">
+          <p>Line 4 is the quiet, necessary sibling to the more theatrical core; it is where Margiela’s radical thinking turns practical without losing its edge. These wardrobe staples—simplified tops, essential draping, clean tailoring—are distillations of the house’s ethos, making conceptual refinements feel like effortless daily habits. They are the clothes that survive season to season, carrying the same subversive DNA in their proportions, internal construction, and contextual detachment.</p>
+          <p>An obsessed reader sees Line 4 as the engine room of accessibility: the place where the Maison’s intellectual labor is smuggled into everyday life. The garments signal their lineage not through loud branding but through small ruptures—unexpected seams, off-kilter alignment, and deliberate restraint—that, once recognized, become markers of an insider’s intimacy with the brand’s grammar.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-5" class="collection" aria-labelledby="title-5">
+      <div class="number-circle" aria-hidden="true">5</div>
+      <div class="texts">
+        <h2 id="title-5">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 5 exists like a ghost in the Maison’s grid: noted more for its absence than any visible presence. That non-assignment is an act of authorship as much as any collection—the decision not to define is a decision to provoke curiosity. The obsessive interpreter treats 5 as a space of latent potential, a withheld narrative, imagining internal iterations, experimental side-steps, or even deliberate erasures that never saw the light of public runway.</p>
+          <p>Its ambiguity is a feature, not a failure. In a system that otherwise attempts (and refrains) to categorize creative output numerically, 5 functions as a conceptual breath, keeping the numbered scheme from ossifying. For those consumed by Margiela’s logic, the silence around 5 amplifies the significance of what is said elsewhere—its emptiness becomes a foil that sharpens the edges of presence.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-6" class="collection" aria-labelledby="title-6">
+      <div class="number-circle" aria-hidden="true">6</div>
+      <div class="texts">
+        <h2 id="title-6">MM6 — diffusion line for women &amp; men</h2>
+        <div class="description">
+          <p>MM6 is both a softer echo and a secretive twin, the diffusion arm that dilutes Margiela’s conceptual poison for regular consumption without losing its molecular structure. Originally trailing as Line 6, it evolved into its own identity, a subtle, insurgent lab where everyday utility is mixed with the same anti-authorial skepticism—loose tailoring, gender-fluid gestures, and graphic restraint, all filtered through a secondary but fiercely autonomous lens.</p>
+          <p>The obsessive fan watches MM6 as a slow burn: it is where the Maison lets speculation meet function. Its identity shifts—rebrands, collaborations, experimental presentations—are studied like constellations, each new alignment revealing how far the house can push accessibility while keeping its mystique intact. MM6 feels like a conversation between devotion and everyday life, a quiet conspiracy that Margiela occupies on the edge of mainstream visibility.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-7" class="collection" aria-labelledby="title-7">
+      <div class="number-circle" aria-hidden="true">7</div>
+      <div class="texts">
+        <h2 id="title-7">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 7 is another of those strategic lacunae that architecture-savvy devotees circle in their mental maps. It isn’t merely unused; its existence on the grid, unarticulated and unpopulated, performs a design choice: absence as intentional texture. In a system that could have easily filled every number with content, the presence of blank slots like 7 creates tension, suggesting that erasure and withholding are as integral to the Maison’s narrative as production.</p>
+          <p>For the obsessively attuned, 7 is speculation territory. It invites the same kind of internal storytelling as 2 and 5—what if it was once tested, what if it’s reserved for future impossibilities, what if its emptiness reflects a philosophical refusal to overdefine? Its value isn’t in what is known about it, but in the reverberations of not knowing.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-8" class="collection" aria-labelledby="title-8">
       <div class="number-circle" aria-hidden="true">8</div>
       <div class="texts">
-        <h2 id="title-8">Collection de lunettes</h2>
+        <h2 id="title-8">Eyewear collection</h2>
+        <div class="description">
+          <p>Line 8 takes the act of looking and makes a quiet architecture of it. Margiela’s eyewear is not decorative flourish; it is a considered re-examination of how the face is framed, how identity is seen and obscured. Clean lines meet purposeful disruption—proportions subtly askew, lenses that suggest function while hinting at conceptual distance, and frames that feel both classic and misaligned, like a memory slightly out of focus.</p>
+          <p>To the obsessive collector, Line 8 embodies the Maison’s talent for turning utility into language. The eyewear is a study in relational design: what you use to see becomes what shapes how you are perceived. It’s a quiet manifesto about visibility, authorship, and the gaze, bundled in objects that are worn daily yet read like coded statements.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-9" class="collection" aria-labelledby="title-9">
+      <div class="number-circle" aria-hidden="true">9</div>
+      <div class="texts">
+        <h2 id="title-9">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 9 is part of the same constellation of deliberate gaps—its presence in the numbering system, unaccompanied by a public narrative, amplifies its function as an open-ended footnote. The obsessive interpreter doesn’t lament the lack of definition; instead, they catalog the silence and layer it with possibility. Was it a shelved concept, a private internal exercise, or a placeholder for a future untold story? The questions become part of Margiela fandom’s ritual.</p>
+          <p>That nothingness offers freedom. In a universe where clarity can calcify into expectation, 9 holds a counterbalance: it manages the tension between brand mythology and unreadability. Its empty slot fosters a landscape where devotion includes accepting certain unknowables, making the rest of the system feel deliberately lived-in rather than overly prescribed.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-10" class="collection" aria-labelledby="title-10">
       <div class="number-circle" aria-hidden="true">10</div>
       <div class="texts">
-        <h2 id="title-10">La collection pour homme</h2>
-      </div>
-    </section>
-
-    <section id="section-14" class="collection" aria-labelledby="title-14">
-      <div class="number-circle" aria-hidden="true">14</div>
-      <div class="texts">
-        <h2 id="title-14">Garde-robe pour homme</h2>
+        <h2 id="title-10">The men’s collection</h2>
+        <div class="description">
+          <p>Line 10 is the masculine counterpart to the women’s core, but to call it “counterpart” flattens the depth of its own language. Here, traditional menswear undergoes surgical decomposition—tailoring is teased apart and reassembled so that the familiar becomes unfamiliar and potent again. The tension between structure and fragmentation is the heartbeat of the line: pieces feel simultaneously grounded in archetype and restless in execution.</p>
+          <p>Obsessives trace the lineage of Margiela’s menswear through the subtle echoes of deconstruction: lapels that suggest absence, cuts that whisper of previous lives, and constructions that require the eye to linger. Line 10 is a study in how masculinity is both worn and questioned; its quiet provocations have earned it a cult reverence as the place where formality is made porous, and identity is given room to breathe.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-11" class="collection" aria-labelledby="title-11">
       <div class="number-circle" aria-hidden="true">11</div>
       <div class="texts">
-        <h2 id="title-11">Collection d'accessoires pour femme & homme</h2>
+        <h2 id="title-11">Accessories collection for women &amp; men</h2>
+        <div class="description">
+          <p>Line 11 exists at the intersection of utility and subversion. Bags, belts, small leather goods, and hybrid items emerge here not simply as appendages to outfits but as autonomous carriers of the Maison’s grammar—playing with expectation through material reassignments, asymmetry, and the unsettling comfort of things that are familiar yet slightly askew. These accessories function like punctuation in the world of Margiela dressing, modulating tone without ever shouting.</p>
+          <p>The obsessive viewer sees Line 11 as a laboratory of detail. Each piece can be traced back to an underlying logic of “what if”: what if a bag reveals its inner stitching, what if a belt camouflages function behind restraint, what if an object is simultaneously jewelry and utility? These questions are answered subtly, season after season, in the quiet manners of craftsmanship that refuse to be loud but demand careful attention.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-12" class="collection" aria-labelledby="title-12">
       <div class="number-circle" aria-hidden="true">12</div>
       <div class="texts">
-        <h2 id="title-12">Collection de joaillerie</h2>
+        <h2 id="title-12">Jewelry collection</h2>
+        <div class="description">
+          <p>Line 12 is where heirloom tradition collides with conceptual fracture. Margiela’s jewelry doesn’t comfort with familiarity; it unsettles by dividing, doubling, and recontextualizing the tokens of legacy—rings that look like they’ve been deconstructed and reassembled, chains that carry echoes of once-complete forms, and hybrid pieces that toy with preciousness while asserting a subtle defiance. There is a ritual of reformation in each piece, an ongoing dialogue between the expected and the ruptured.</p>
+          <p>The obsessed collector regards Line 12 as a secret language written in metal and gemstone. The line reframes what jewelry means, turning sentimental objects into layered narratives; craftsmanship is in service of interrogation, and every subtle imperfection—scratches, splits, overlapping elements—is deliberate, a proof of intentional authorship masked as accidental grace.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-13" class="collection" aria-labelledby="title-13">
       <div class="number-circle" aria-hidden="true">13</div>
       <div class="texts">
-        <h2 id="title-13">Objets & éditions</h2>
+        <h2 id="title-13">Objects &amp; editions</h2>
+        <div class="description">
+          <p>Line 13 spills the brand out of the body and into environments. Whether it’s a catalog that reads like a quiet manifesto, a sculptural object that bends utility into conceptual allegory, or a limited-edition piece that reinterprets domesticity, these editions extend Margiela’s ideology beyond dressing. They are curated artifacts that provoke how one inhabits space, asking the same questions about identity and authorship that appear in clothing, but in unexpected physical forms.</p>
+          <p>For the devotee, Line 13 is proof that Margiela’s obsession isn’t confined to fabric: it’s systemic. The objects accumulate like marginalia to a broader philosophical text—each edition a footnote, each design a reconsideration of the everyday. They offer layers of meaning for those who look closely and reward repetition with new readings, making the non-wearable as vital to the mythology as what hangs on the body.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-14" class="collection" aria-labelledby="title-14">
+      <div class="number-circle" aria-hidden="true">14</div>
+      <div class="texts">
+        <h2 id="title-14">Men’s wardrobe</h2>
+        <div class="description">
+          <p>Line 14 provides the quiet foundation beneath the experimental peaks of Line 10. It is an exercise in essentialism, refining masculine form into pieces that feel familiar and subtly destabilized—simple shirts, pared-down trousers, and wardrobe anchors that accumulate nuance only upon inspection. The magic is in the restraint: stitches that interrupt symmetry, proportion that slightly misses convention, and construction that hints at deconstruction without collapsing into spectacle.</p>
+          <p>The fanatic of Margiela sees in Line 14 the interplay between everyday survival and conceptual rigor. These are the clothes worn as armor and thought experiment simultaneously, where the circled “14” label acts as a secret handshake: you recognize the lineage, you feel the lineage, and you understand that normalcy here has been recalibrated.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-15" class="collection" aria-labelledby="title-15">
+      <div class="number-circle" aria-hidden="true">15</div>
+      <div class="texts">
+        <h2 id="title-15">Special collaborations / limited editions</h2>
+        <p>(e.g., Margiela × 3 Suisses)</p>
+        <div class="description">
+          <p>Line 15 is a margin of eccentricity where Margiela experiments with distribution, authorship, and audience expectation. Collaborations cloaked with irony—like the early catalog-based capsule with 3 Suisses—deployed the system’s aesthetics to dilute the hierarchy between high concept and mass access. These projects read like puzzles: familiar formats (mail-order, partnership) disrupted by inverted logic, tongue-in-cheek construction, and layers of conceptual snark.</p>
+          <p>To the obsessed observer, Line 15 is where the brand plays with its own reflection. It opens the system up to self-aware distortion—collaboration becomes critique, accessibility becomes subversion, and commerciality becomes a stage for artistic interference. The limited and ephemeral nature of these editions only intensifies their cult status; they feel like secret chapters in a manifestly non-linear book.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-16" class="collection" aria-labelledby="title-16">
+      <div class="number-circle" aria-hidden="true">16</div>
+      <div class="texts">
+        <h2 id="title-16">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 16 is another deliberate void, a number that provokes the same fevered hypotheses as its silent siblings. There’s a sense among devotees that its emptiness is a kind of quiet architecture of possibility—an unspoken permission slip for the house to pause, pivot, or invent outside the constraints of expectation. Not assigning a collection to it is a declarative act: the system is not a checklist, it is a living field with uncharted territories.</p>
+          <p>For someone obsessed, these non-assignments are treasures in absence. Line 16 becomes a canvas for what-ifs, a placeholder in mental narratives where future archaeology might discover a buried experiment, or not. It is the kind of silence that invites listening, and in the context of Margiela’s practice, silence often holds as much meaning as the most elaborate deconstruction.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-17" class="collection" aria-labelledby="title-17">
+      <div class="number-circle" aria-hidden="true">17</div>
+      <div class="texts">
+        <h2 id="title-17">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>There is reverence in the gap that Line 17 presents. Its lack of a publicly articulated purpose doesn’t diminish its presence; instead, it deepens the grid’s complexity. Those who study Margiela’s system see 17 as a quiet rebellion against completeness—by leaving it undefined, the Maison resists the temptation to formalize every aspect of its identity, keeping parts of its ontology unpinned and open.</p>
+          <p>The obsessive mind layers over 17 the same narratives spun around its fellow voids: what internal logic might have been tested here, what season held a prototype that never saw light, and how much of this deliberate opacity is performative? Such questions keep the dialogue about the brand active—17’s emptiness ensures that curiosity remains central to the experience.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-18" class="collection" aria-labelledby="title-18">
+      <div class="number-circle" aria-hidden="true">18</div>
+      <div class="texts">
+        <h2 id="title-18">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 18 sits in that rarefied zone of absence with a quiet, almost dignified presence. It is one of the structural “gaps” that prevents the numerical schema from becoming dogmatic; its lack of assignment is a gesture of restraint, preserving the system’s elasticity. For aficionados, 18 is a mental resting place, a place where the known and the unknown meet and create tension that sustains long-term engagement with the brand’s semiotics.</p>
+          <p>The strategic emptiness of 18 encourages the obsessive to look elsewhere with fresh eyes. Knowing there are unfilled slots like this in the architecture keeps interpretation from calcifying—the Maison’s universe feels alive, because some parts are intentionally left unwritten. That kind of design humility, paradoxically, becomes a source of depth.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-19" class="collection" aria-labelledby="title-19">
+      <div class="number-circle" aria-hidden="true">19</div>
+      <div class="texts">
+        <h2 id="title-19">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 19 is another quiet cipher in the grid’s grammar. Its public non-use doesn’t feel like neglect but like an intentional space carved for possibility or performance. For the devotee, its presence compels the question: was there once a prototype, a seasonal experiment, or a conceptual idea that was tasted and withdrawn? The absence is textured, a signal that the system includes room for retreat as much as it does for display.</p>
+          <p>This kind of unsaid territory keeps the broader structure from ossifying. 19’s mystery functions as a stabilizing paradox—how can something be both present and undefined? That is exactly the tension Margiela cultivates: the ability to let meaning slip, only to be regrasped by those who pay attention.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-20" class="collection" aria-labelledby="title-20">
+      <div class="number-circle" aria-hidden="true">20</div>
+      <div class="texts">
+        <h2 id="title-20">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 20 exists as a silent affirmation of the Maison’s refusal to over-explain. Its lack of a visible identity becomes a kind of design punctuation that says “we could, but we choose not to.” The obsessive reader appreciates that these numerical voids serve as counterweight to the brand’s intricate overtness elsewhere—20’s blankness allows other lines to feel curated rather than exhaustive.</p>
+          <p>The conceptual space of 20 invites speculation without demanding answers. It is the kind of quiet promise that keeps curiosity active: if the system is not finished, then the story remains open. That open-endedness is what makes Margiela feel less like a static archive and more like an ongoing practice in meaning-making.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="section-21" class="collection" aria-labelledby="title-21">
+      <div class="number-circle" aria-hidden="true">21</div>
+      <div class="texts">
+        <h2 id="title-21">—</h2>
+        <p>Not used / no official assignment.</p>
+        <div class="description">
+          <p>Line 21 is part of the lacework of intentional silences scattered across the grid. It’s not a deficiency; it’s a design choice—permitting gaps ensures that the Maison never fully closes its ontology, that interpretations can shift, breathe, and remain personal. The number’s existence without a label is a challenge to completionism and a nod to the idea that identity, even in a highly codified system, can hold some unspoken spaces.</p>
+          <p>For the obsessive, 21 is fertile ground. The absence doesn’t frustrate so much as it stimulates narrative layering: imagined capsules, retired experiments, or ideas held back for moments that haven’t arrived. It’s that latent content that pulls the curious deeper—what remains unwritten is often what haunts the most.</p>
+        </div>
       </div>
     </section>
 
     <section id="section-22" class="collection" aria-labelledby="title-22">
       <div class="number-circle" aria-hidden="true">22</div>
       <div class="texts">
-        <h2 id="title-22">Collection de chaussures pour femme & homme</h2>
+        <h2 id="title-22">Footwear collection for women &amp; men</h2>
+        <div class="description">
+          <p>Shoes under Line 22 are where Margiela’s treatment of the body’s interface with the ground becomes aesthetic theory. They are rarely decorative in a traditional sense; instead, they interrogate balance, reference, and construction—often suggesting wear histories through deliberate distress, playing with proportion so that the foot becomes both anchor and point of tension. The label logic here is quiet, but the design speaks in a dialect of reimagined function.</p>
+          <p>Obsessives study the silhouettes of Line 22 as if reading a manifesto: the way a sole is displaced, a tongue reintegrated after deconstruction, or a heel subtly misaligned reveals a depth of intention. These shoes are wearable relics, carrying the same philosophy as the clothing—foundations reconstructed, identity hinted, and presence made complex in a terrain that literally supports everything.</p>
+        </div>
       </div>
     </section>
 
-    
-
-    <!-- Placeholder sections for other numbers (optional) -->
-    <section id="section-2" class="collection" aria-label="Placeholder">
-      <div class="number-circle" aria-hidden="true">2</div>
+    <section id="section-23" class="collection" aria-labelledby="title-23">
+      <div class="number-circle" aria-hidden="true">23</div>
       <div class="texts">
-        <h2>—</h2>
-        <p>Contenu à venir.</p>
+        <h2 id="title-23">—</h2>
+        <p>Unused / ambiguous / sporadic projects</p>
+        <div class="description">
+          <p>Line 23 is the grid’s final unresolved note, an open question mark that resists tidy categorization. It surfaces occasionally in fringe discussions, not as a defined system but as a symbolic trace of the Maison’s commitment to keeping some of its architecture unanchored. That ambiguity becomes its allure: it feels like a late footnote in a novel that suggests alternative endings, might-have-beens, or future whispers.</p>
+          <p>For the devout Margiela scholar, 23 exemplifies the brand’s strength in non-resolution. The number’s undefinition encourages layered myth-making—its possible pasts and futures occupy intellectual space, and every encounter with the Maison is tinged with the awareness that not everything has been spelled out. In that suspended uncertainty, the brand’s obsessive admirers find an enduring invitation to keep watching, reading, and sensing.</p>
+        </div>
       </div>
     </section>
 
     <footer>
-      *Etiquette toute blanche
+      *All-white label
     </footer>
   </main>
 
@@ -324,25 +512,6 @@
       function initAccordion() {
         const sections = document.querySelectorAll('.collection');
         sections.forEach(section => {
-          const texts = section.querySelector('.texts');
-          const desc = document.createElement('div');
-          desc.className = 'description';
-
-          const contents = [];
-          const existing = texts.querySelector('p');
-          if (existing) {
-            contents.push(existing.innerHTML);
-            existing.remove();
-          }
-          contents.push('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.');
-          contents.push('Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.');
-          contents.slice(0, 2).forEach(text => {
-            const p = document.createElement('p');
-            p.innerHTML = text;
-            desc.appendChild(p);
-          });
-          texts.appendChild(desc);
-
           section.addEventListener('click', e => {
             if (e.target.closest('.description')) return;
             const isActive = section.classList.contains('active');


### PR DESCRIPTION
## Summary
- Populate home page with full descriptions for Maison Margiela collections 0–23
- Simplify accordion script to use static descriptions
- Note all-white label in page footer

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/mmm/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_688e9b899cb083338cf2934d44d767b5