### PR TITLE
Add brand style instructions in AGENTS file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+## Brand Colors
+- **White** (`#fff`) for page backgrounds.
+- **Black** (`#000`) for text and borders.
+- **Neutral Gray** (`#e0e0e0`) for subtle accents and surfaces.
+
+## Fonts
+- Use **"Goudy Bookletter 1911"**, falling back to Georgia and "Times New Roman", for body text.
+- Use **"Inter"** (with system fallbacks) for navigation, labels, and interface elements.
+
+## Number Styling
+- All numerical markers must appear inside a circle using the `.number-circle` class.
+- Circles use a `2px` solid black border and `50%` border radius.
+- Keep this style when adding new lines or collections to maintain brand consistency.


### PR DESCRIPTION
## Summary
- add AGENTS brand guide with color palette, fonts, and number-circle usage instructions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e9ec06b7c8333a94c7bc7446dc027