### PR TITLE
Clone collection style on detail page

### DIFF
--- a/collection.html
+++ b/collection.html
@@ -31,18 +31,11 @@
           .then(html => {
             const parser = new DOMParser();
             const doc = parser.parseFromString(html, 'text/html');
-            const section = doc.querySelector(`#section-${number} .texts`);
+            const section = doc.querySelector(`#section-${number}`);
             if (section && info) {
-              const title = section.querySelector('h2');
-              const desc = section.querySelector('.description');
-              if (title) {
-                const h3 = document.createElement('h3');
-                h3.textContent = title.textContent;
-                info.appendChild(h3);
-              }
-              if (desc) {
-                info.appendChild(desc.cloneNode(true));
-              }
+              const clone = section.cloneNode(true);
+              clone.classList.add('active');
+              info.appendChild(clone);
             }
           });
       }

--- a/styles.css
+++ b/styles.css
@@ -26,17 +26,6 @@ main {
   margin-top: 1rem;
 }
 
-#collection-info h3 {
-  margin: 0 0 0.5rem;
-  font-size: 1.2rem;
-}
-
-#collection-info .description p {
-  margin: 0.5rem 0;
-  font-size: 0.95rem;
-  line-height: 1.4;
-}
-
 footer {
   background: #fff;
   text-align: center;
@@ -68,4 +57,56 @@ footer {
   width: 100%;
   height: 200px;
   border-radius: 10px;
+}
+
+.collection {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin: 1.5rem 0;
+  cursor: pointer;
+}
+
+.number-circle {
+  flex: 0 0 auto;
+  width: 50px;
+  height: 50px;
+  border: 2px solid #000;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1rem;
+  position: relative;
+  margin-top: 2px;
+}
+
+.texts {
+  flex: 1;
+}
+
+.texts h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: normal;
+}
+
+.texts p {
+  margin: 4px 0 0;
+  font-size: 0.95rem;
+}
+
+.description {
+  display: none;
+  margin-top: 0.5rem;
+}
+
+.collection.active .description {
+  display: block;
+}
+
+.asterisk {
+  font-size: 1.2rem;
+  vertical-align: top;
 }


### PR DESCRIPTION
## Summary
- Display full collection section on detail page with original number circle and text
- Add shared CSS for collection layout and number circle styling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688ea09c82fc83338166ac5159a85bf4