### PR TITLE
Double collection item height on click

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -66,9 +66,8 @@ footer {
 }
 
 .squaricle-card.expanded {
-  grid-column: 1 / -1;
-  width: 100%;
-  height: 200px;
+  grid-row: span 2;
+  aspect-ratio: 1 / 2;
   border-radius: 10px;
 }
 


### PR DESCRIPTION
## Summary
- Make collection grid items span two rows and double height when clicked

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_b_688ec2bc59cc833389e8bac92516c3ff